### PR TITLE
Revert "use .invoke rather than .run for RSpec runner"

### DIFF
--- a/lib/quest/quest_watcher.rb
+++ b/lib/quest/quest_watcher.rb
@@ -31,7 +31,7 @@ module Quest
       loader = config.send(:formatter_loader)
       notifications = loader.send(:notifications_for, RSpec::Core::Formatters::JsonFormatter)
       reporter.register_listener(formatter, *notifications)
-      RSpec::Core::Runner.invoke(["#{@quest_dir}/#{@active_quest}/#{@active_quest}_spec.rb"])
+      RSpec::Core::Runner.run(["#{@quest_dir}/#{@active_quest}/#{@active_quest}_spec.rb"])
       File.open(File.join(@state_dir, "#{@active_quest}.json"), "w"){ |f| f.write(formatter.output_hash.to_json) }
       RSpec.reset
     end


### PR DESCRIPTION
As it turns out, this doesn't work at all. I'm not sure what was going on when I tried to test it that made it seem to.
Reverts puppetlabs/quest#16