### PR TITLE
refactor API

### DIFF
--- a/bin/quest
+++ b/bin/quest
@@ -3,18 +3,56 @@
 begin
   require 'quest'
   require 'gli'
+  require 'net/http'
+  require 'json'
 rescue
   require 'rubygems'
   require 'quest'
   require 'gli'
+  require 'json'
 end
 
 module GLIWrapper
-  include Quest::Messenger
   include GLI::App
   extend self
 
-  # Quest tools
+  BASE_URI = URI('http://localhost:4567/')
+
+  def get_path(*path)
+    Net::HTTP.get(URI.join(BASE_URI, *path))
+  end
+
+  def post_path(form_data, *path)
+    Net::HTTP.post_form(URI.join(BASE_URI, *path), form_data)
+  end
+
+  def offer_bailout(message)
+    print "#{message} Continue? [Y/n]:"
+    raise "Cancelled" unless [ 'y', 'yes', ''].include? STDIN.gets.strip.downcase
+  end
+
+  def fancy_status
+    active_quest = get_path('active_quest')
+    output = "Quest: #{active_quest}\n"
+    examples = JSON.parse(get_path('status/', 'examples'))
+    examples.each do |example|
+      if example["status"] == "passed"
+        output << '√ '.green
+      else
+        output << 'X '.yellow
+      end
+      output << example["full_description"] + "\n"
+    end
+    output
+  end
+
+  def summary_status
+    active_quest = get_path('active_quest')
+    output = "Quest: #{active_quest} - Progress: "
+    summary = JSON.parse(get_path('status/', 'summary'))
+    complete_count = summary["example_count"].to_i - summary["failure_count"].to_i
+    output << "#{complete_count} of #{summary['example_count']} tasks."
+  end
 
   program_desc 'Track the status of quests and tasks.'
 
@@ -25,39 +63,30 @@ module GLIWrapper
     c.action do |global_options, options, args|
       if args.length < 1
         raise 'You must specify a quest name. Refer to the Quest Guide or use the "quest list" command.'
-      end
-      unless quests.include? args[0]
-        puts "test"
+      elsif not JSON.parse(get_path('quests')).include? args[0]
         raise "#{args[0]} is not a valid quest name. Refer to the Quest Guide or use the \"quest list\" command."
-      end
-      unless active_quest_complete?
+      elsif not get_path('status/', 'summary/', 'failure_count') == '0'
         offer_bailout("The current quest is not complete. If you begin a new quest, your agent nodes will be reset. Your master node and Puppet code will not be affected.\n")
       end
-      change_quest(args[0])
+      post_path({}, 'begin/', args[0])
     end
   end
 
   desc 'List available quests'
   command :list do |c|
     c.action do |global_options, options, args|
-      puts quests
+      puts JSON.parse(get_path('quests'))
     end
   end
 
   desc 'Show status of the current quest'
   command :status do |c|
     c.switch [:s], :desc => 'Show status in summary form.'
-    c.switch [:n], :desc => 'Show status in summary form, no colorisation.'
-    c.switch [:j], :desc => 'Show status in JSON format. (For debugging)'
     c.action do |global_options, options, args|
       if options[:s]
-        puts status(:brief => true)
-      elsif options[:n]
-        puts status(:brief => true, :color => false)
-      elsif options[:j]
-        puts status(:raw => true) 
+        puts summary_status 
       else
-        puts status
+        puts fancy_status
       end
     end
   end

--- a/bin/questctl
+++ b/bin/questctl
@@ -11,7 +11,6 @@ end
 
 module GLIWrapper
   include GLI::App
-  include Quest::Messenger
   extend self
 
   # Controllers for the quest service
@@ -21,41 +20,19 @@ module GLIWrapper
 
   desc 'Start the quest service'
   command :start do |c|
-    c.switch [:d, :daemonize], :desc => 'Daemonize the quest watcher process. Defaults to true.', :default_value => true
-    c.flag [:q, :quest_dir, 'quest_dir'], :desc => 'Specify the quest content directory.'
+    c.flag [:q, :task_dir, 'task_dir'], :desc => 'Specify the task directory.'
     c.action do |global_options, options, args|
-      validate_quest_dir(options[:quest_dir])
-      initialize_state_dir
-      save_state(options)
-      watcher = Quest::QuestWatcher.new(daemonize=options[:d])
-      watcher.run!
-    end
-  end
-  desc 'Stop the quest service'
-  command :stop do |c|
-    c.action do |global_options, options, args|
-      send_quit
-    end
-  end
-  desc 'Restart the quest service'
-  command :restart do |c|
-    c.action do |global_options, options, args|
-      send_quit
-      watcher = Quest::QuestWatcher.new
-      watcher.run!
-    end
-  end
-  desc 'Show the status of the quest service'
-  command :status do |c|
-    c.action do |global_options, options, args|
-      if File.exist?(PIDFILE)
-        puts "active"
-        puts "PID: " + pid.to_s
-      else
-        puts "inactive"
+      messenger = Quest::Messenger.new( {'task_dir' => options[:task_dir]} )
+      api = Thread.new do
+        Quest::API.set :messenger, messenger
+        Quest::API.run!
       end
+      watcher = Thread.new do
+        Quest::QuestWatcher.new(messenger).run!
+      end
+      watcher.join
+      api.join
     end
   end
-
   exit run(ARGV)
 end

--- a/lib/quest/messenger.rb
+++ b/lib/quest/messenger.rb
@@ -1,48 +1,43 @@
 # -*- encoding : utf-8 -*-
 module Quest
 
-  module Messenger
+  # Shared state and methods for reading from the content directory
+  class Messenger
 
     require 'fileutils'
 
-    STATE_DIR = '/var/opt/quest'
-    PIDFILE = '/var/run/quest.pid'
+    attr_reader   :quest_index_file
+    attr_reader   :spec_helper
+    attr_accessor :active_quest
+    attr_accessor :quest_status
 
-    def set_state(opts={})
-      quest_dir = opts[:quest_dir] || File.join(Dir.pwd, 'quests')
-      {
-        'quest_dir' => quest_dir,
-        'quests'    => read_json(File.join(quest_dir, 'index.json'))
-      }
+    def initialize(config = {})
+      @task_dir  = config['task_dir']  || Dir.pwd
+      @quest_index_file  = File.join(@task_dir, 'index.json')
+      validate_task_dir
+      @spec_helper       = File.join(@task_dir, 'spec_helper.rb')
+      @quest_status = {}
+      @active_quest = quests.first
     end
 
-    def save_state(opts={})
-      File.open(File.join(STATE_DIR, 'state.json'), 'w') do |f|
-        f.write(set_state(opts).to_json)
-      end
+    def set_raw_status(quest, raw_status_hash)
+      @quest_status[quest] = raw_status_hash
     end
 
-    def validate_quest_dir(path)
+    def validate_task_dir
       begin
-        read_json(File.join(path, 'index.json'))
+        JSON.parse(File.read(@quest_index_file))
       rescue
-        puts "No valid quest index.json file found in #{path}. Run this command from a directory containing such a file, or specify one with the --quest_dir flag."
+        puts "No valid quest index.json file found at #{@quest_index_file}"
         exit 1
       end
     end
 
-    def set_active_quest(quest)
-      File.open(File.join(STATE_DIR, 'active_quest'), 'w') do |f|
-        f.write(quest)
-      end
-      run_setup_command
-    end
-
-    def run_setup_command
-      if setup_command
+    def run_setup_command(quest)
+      if setup_command(quest)
         begin
           puts "Setting up the #{active_quest} quest..."
-          Dir.chdir(quest_dir){
+          Dir.chdir(@task_dir){
             setup_io = IO.popen(setup_command) do |io|
               io.each do |line|
                 puts line
@@ -55,121 +50,22 @@ module Quest
       end
     end
 
-    def offer_bailout(message)
-      print "#{message} Continue? [Y/n]:"
-      raise "Cancelled" unless [ 'y', 'yes', ''].include? STDIN.gets.strip.downcase
-    end
-
-    def active_quest_complete?
-      raw_status["summary"]["failure_count"] == 0
-    end
-
-    def set_first_quest
-      first_quest = quests.first
-      set_active_quest(first_quest)
-    end
-
-    def initialize_state_dir
-      FileUtils.mkdir_p STATE_DIR
-    end
-
-    def read_json(path)
-      JSON.parse(File.read(path))
-    end
-
-    def get_state_hash
-      read_json(File.join(STATE_DIR, 'state.json'))
-    end
-
-    def quest_dir
-      get_state_hash['quest_dir']
-    end
-
-    def spec_helper
-      File.join(quest_dir, 'spec_helper.rb')
-    end
-
-    def active_quest_spec_path
-      File.join(quest_dir, "#{active_quest}_spec.rb")
+    def spec_path(quest)
+      File.join(@task_dir, "#{quest}_spec.rb")
     end
 
     def quests
-      read_json(File.join(quest_dir, 'index.json')).keys
-    end
-
-    def active_quest
-      set_first_quest unless File.exists?(File.join(STATE_DIR, 'active_quest'))
-      File.read(File.join(STATE_DIR, 'active_quest'))
-    end
-
-    def active_quest_json_output_path
-      File.join(STATE_DIR, "#{active_quest}.json")
-    end
-
-    def status_line_output_path
-      File.join(STATE_DIR, "active_quest_status")
-    end
-
-    def quest_watch
-      read_json(File.join(quest_dir, "index.json"))[active_quest]["watch_list"]
+      JSON.parse(File.read(@quest_index_file)).keys
     end
 
     def setup_command
-      read_json(File.join(quest_dir, "index.json"))[active_quest]["setup_command"]
+      JSON.parse(File.read(@quest_index_file))[active_quest]["setup_command"]
     end
 
-    def raw_status
-      JSON.parse(File.read(File.join(STATE_DIR, "#{active_quest}.json")))
-    end
-
-    def status( options = {:brief => false, :color => true, :raw => false } )
-      return raw_status if options[:raw]
-
-      quest_name = options[:color] ? active_quest.cyan : active_quest
-
-      output = "Quest: " + quest_name
-
-      if options[:brief]
-        total = raw_status["summary"]["example_count"]
-        complete = total - raw_status["summary"]["failure_count"]
-        output << " - Progress: #{complete} of #{total} Tasks."
-      else
-        # Add line break after quest name for full output
-        output << "\n"
-        raw_status["examples"].each do |example|
-          if example["status"] == "passed"
-            output << '√ '.green
-          else
-            output << 'X '.yellow
-          end
-          output << example["full_description"] + "\n"
-        end
+    def begin_quest(quest)
+      if quests.include?(quest)
+        @active_quest = quest
       end
-
-      output
-    end
-
-    def pid
-      begin
-        File.read(PIDFILE).to_i
-      rescue
-        puts "The quest service isn't running. Use the questctl command to start the service."
-        raise
-      end
-    end
-
-    def send_reset
-      Process.kill("HUP", pid)
-    end
-
-    def send_quit
-      Process.kill("QUIT", pid)
-    end
-
-    def change_quest(quest)
-      set_active_quest(quest)
-      send_reset
-      puts "You are now on the " + active_quest.cyan + " quest."
     end
 
   end

--- a/lib/quest/quest_watcher.rb
+++ b/lib/quest/quest_watcher.rb
@@ -4,110 +4,35 @@ module Quest
 
   class QuestWatcher
 
-    include Quest::Messenger
     include Quest::SpecRunner
 
-    def initialize(daemonize=true)
-      @daemonize = daemonize
+    def initialize(messenger)
+      @messenger = messenger
       @timers = Timers::Group.new
-    end
-
-    def restart_watcher
-      if @watcher
-        @watcher.pause
-        Quest::LOGGER.info("Watcher paused")
-        @watcher.finalize
-        Quest::LOGGER.info("Watcher finalized pending runs")
-        @watcher.filenames = quest_watch
-        Quest::LOGGER.info("Watcher file names set to #{quest_watch}")
-        @watcher.resume
-        Quest::LOGGER.info("Watcher resumed")
-      else
-        Quest::LOGGER.info("No watcher instance found. Skipping watcher restart.")
-      end
-    end
-
-    def write_pid
-      begin
-        File.open(PIDFILE, File::CREAT | File::EXCL | File::WRONLY){|f| f.write("#{Process.pid}") }
-        Quest::LOGGER.info("PID written to #{PIDFILE}")
-        at_exit { File.delete(PIDFILE) if File.exists?(PIDFILE) }
-      rescue Errno::EEXIST
-        check_pid
-        retry
-      end
-    end
-
-    def check_pid
-      case pid_status
-      when :running, :not_owned
-        puts "The quest watcher is already running. Check #{PIDFILE}"
-        exit 1
-      when :dead
-        File.delete(PIDFILE)
-      end
-    end
-
-    def pid_status
-      return :exited unless File.exists?(PIDFILE)
-      pid = File.read(PIDFILE).to_i
-      return :dead if pid == 0
-      Process.kill(0, pid)
-      :running
-    rescue Errno::ESRCH
-      :dead
-    rescue Errno::EPERM
-      :not_owned
-    end
-
-    def trap_signals
-      trap(:HUP) do
-        restart_watcher
-      end
-      Quest::LOGGER.info("Trap for HUP signal set")
-    end
-
-    def start_watcher
-      Quest::LOGGER.info('Starting initial spec run')
-      test_current_quest_and_write_output
-      Quest::LOGGER.info("Initializing watcher watching for changes in #{quest_watch}")
-      @watcher = FileWatcher.new(quest_watch)
-      @watcher_thread = Thread.new(@watcher) do |watcher|
-        watcher.watch do |changed_file_path|
-          Quest::LOGGER.info("Watcher triggered by a change to #{changed_file_path}")
-          test_current_quest_and_write_output
-        end
-      end
+      @lock = Mutex.new
     end
 
     def start_timer
       task_timer = @timers.now_and_every(5) do
-        @timers.pause
-        test_current_quest_and_write_output
-        @timers.resume
+        unless @lock.locked?
+          @lock.lock
+          check_active_quest
+          @lock.unlock
+        end
       end
       loop {@timers.wait}
     end
 
-    def test_current_quest_and_write_output
-      spec_output_hash = run_spec(active_quest_spec_path)
-      write_json_output(spec_output_hash, active_quest_json_output_path)
-      write_status_line(status_line_output_path)
+    def check_active_quest
+      quest = @messenger.active_quest
+      raw_status = run_spec(@messenger.spec_path(quest))
+      @messenger.set_raw_status(quest, raw_status)
     end
 
     # This is the main function to set up and run the watcher process
     def run!
-      if @daemonize
-        check_pid
-        Process.daemon
-      end
-      write_pid
-      trap_signals
       load_helper
       start_timer
-      # Keep a sleeping thread to handle signals.
-      thread = Thread.new { sleep }
-      thread.join
     end
 
   end

--- a/lib/quest/spec_runner.rb
+++ b/lib/quest/spec_runner.rb
@@ -11,24 +11,21 @@ module Quest
 
     def load_helper
       # Require a spec helper file if it exists
-      if File.exists?(spec_helper)
-        load spec_helper
-        Quest::LOGGER.info("Loaded spec helper at #{spec_helper}")
+      if File.exist?(@messenger.spec_helper)
+        load @messenger.spec_helper
+        Quest::LOGGER.info("Loaded spec helper at #{@messenger.spec_helper}")
       else
-        Quest::LOGGER.info("No spec_helper file found in #{quest_dir}")
+        Quest::LOGGER.info("No spec_helper file found in #{@messenger.spec_helper}")
       end
 
+      rspec_config = RSpec.configuration
+      @formatter = RSpec::Core::Formatters::JsonFormatter.new(StringIO.new)
 
-      config = RSpec.configuration
-      @formatter = RSpec::Core::Formatters::JsonFormatter.new(config.output_stream)
-      # Disable Standard out
-      config.output_stream = File.open("/dev/null", "w")
-
-      # This uses private methods, so it may not respect semver!! If things
+      # This uses private methods, so it may not respect semver. If things
       # break with a new version, be suspicious of this code.
-      reporter  = RSpec::Core::Reporter.new(config)
-      config.instance_variable_set(:@reporter, reporter)
-      loader = config.send(:formatter_loader)
+      reporter  = RSpec::Core::Reporter.new(rspec_config)
+      rspec_config.instance_variable_set(:@reporter, reporter)
+      loader = rspec_config.send(:formatter_loader)
       notifications = loader.send(:notifications_for, RSpec::Core::Formatters::JsonFormatter)
       reporter.register_listener(@formatter, *notifications)
       # End workaround
@@ -47,17 +44,6 @@ module Quest
       Quest::LOGGER.info("RSpec reset")
 
       return output_hash
-    end
-
-    def write_json_output(output_hash, path)
-      File.open(path, "w"){ |f| f.write(output_hash.to_json) }
-      Quest::LOGGER.info("RSpec output written to #{path}")
-    end
-
-    def write_status_line(path)
-      status_line = status( options = {:brief => true, :color => false, :raw => false })
-      File.open(path, "w"){ |f| f.write(status_line) }
-      Quest::LOGGER.info("Status line written to #{path}")
     end
 
   end

--- a/quest.gemspec
+++ b/quest.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = 'quest'
-  spec.version = '0.2.2'
+  spec.version = '1.0.0'
   spec.authors = ['Kevin Henner']
   spec.email = ['kevin@puppetlabs.com']
   spec.summary = 'Track completion of configuration management tasks.'
@@ -12,17 +12,16 @@ Gem::Specification.new do |spec|
   spec.license = 'Apache 2.0'
 
   spec.files = %w( README.md LICENSE )
-  spec.files += Dir['{bin,lib,erb,public}/**/*']
-  spec.executables = ['quest','questctl', 'ballad', 'test_all_quests']
+  spec.files += Dir['{bin,lib}/**/*']
+  spec.executables = ['quest','questctl','test_all_quests']
   spec.require_paths = ['lib']
   spec.add_dependency 'activesupport', '~> 4.2'
   spec.add_dependency 'serverspec', '~> 2.19'
   spec.add_dependency 'json', '~> 1.7'
-  spec.add_dependency 'filewatcher', '~> 0.5'
   spec.add_dependency 'rack', '~> 1.6'
-  spec.add_dependency 'grape', '~> 0.12'
   spec.add_dependency 'gli', '~> 2.12'
   spec.add_dependency 'mono_logger', '~> 1.1'
+  spec.add_dependency 'sinatra'
   spec.add_dependency 'highline'
   spec.add_dependency 'net-ssh'
   spec.add_dependency 'timers'


### PR DESCRIPTION
This is a major refactor of the tool. The quest started by the questctl command now provides a RESTful api as well as the RSpec-in-a-loop quest monitoring. The `quest` command-line tool is now a wrapper for calls to this API. Moving to this API approach lets us keep all the status in memory, and eliminates the need for messy storage of data in the filesystem.