### PR TITLE
Combined two messages from two cases.

### DIFF
--- a/bin/quest
+++ b/bin/quest
@@ -100,7 +100,7 @@ module GLIWrapper
       if args.length < 1
         raise _('You must specify a quest name. Refer to the Quest Guide or use the "quest list" command.')
       elsif not JSON.parse(get_path('quests')).include? args[0]
-        raise _("%{quest} is not a valid quest name. Refer to the Quest Guide or use the "quest list" command.') % {quest: args[0]}
+        raise _('%{quest} is not a valid quest name. Refer to the Quest Guide or use the "quest list" command.') % {quest: args[0]}
       elsif OFFER_BAILOUT and not get_path('status/', 'summary/', 'failure_count') == '0'
         offer_bailout(_("The current quest is not complete. If you begin a new quest, your agent nodes will be reset. Your master node and Puppet code will not be affected.\n"))
       end

--- a/bin/quest
+++ b/bin/quest
@@ -98,9 +98,9 @@ module GLIWrapper
   command :begin do |c|
     c.action do |global_options, options, args|
       if args.length < 1
-        raise _('You must specify a quest name.') + _('Refer to the Quest Guide or use the "quest list" command.')
+        raise _('You must specify a quest name. Refer to the Quest Guide or use the "quest list" command.')
       elsif not JSON.parse(get_path('quests')).include? args[0]
-        raise _("%{quest} is not a valid quest name.") % {quest: args[0]} + _('Refer to the Quest Guide or use the "quest list" command.')
+        raise _("%{quest} is not a valid quest name. Refer to the Quest Guide or use the "quest list" command.') % {quest: args[0]}
       elsif OFFER_BAILOUT and not get_path('status/', 'summary/', 'failure_count') == '0'
         offer_bailout(_("The current quest is not complete. If you begin a new quest, your agent nodes will be reset. Your master node and Puppet code will not be affected.\n"))
       end

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -6,7 +6,7 @@ gettext:
   # called <project_name>.pot?
   project_name: 'quest'
   # This is used in comments in the .pot and .po files to indicate what
-  # project the files belong to and should bea little more desctiptive than
+  # project the files belong to and should be a little more descriptive than
   # <project_name>
   package_name: Quest
   # The locale that the default messages in the .pot file are in


### PR DESCRIPTION
This resolution will allow the translator to decide if there should be a space between the two sentences.
In Japanese, the period (full stop) is used to separate from the next sentence. In English, we need a space character after the period. The quest.pot file will need to be regenerated.