### PR TITLE
(LEARNVM-643) Separate string resource back to two 

### DIFF
--- a/bin/quest
+++ b/bin/quest
@@ -98,9 +98,9 @@ module GLIWrapper
   command :begin do |c|
     c.action do |global_options, options, args|
       if args.length < 1
-        raise _('You must specify a quest name. Refer to the Quest Guide or use the "quest list" command.')
+        raise _('You must specify a quest name. %{refer_to}') % {refer_to: _('Refer to the Quest Guide or use the "quest list" command.')}
       elsif not JSON.parse(get_path('quests')).include? args[0]
-        raise _('%{quest} is not a valid quest name. Refer to the Quest Guide or use the "quest list" command.') % {quest: args[0]}
+        raise _('%{quest} is not a valid quest name. %{refer_to}') % {quest: args[0], refer_to: _('Refer to the Quest Guide or use the "quest list" command.')}
       elsif OFFER_BAILOUT and not get_path('status/', 'summary/', 'failure_count') == '0'
         offer_bailout(_("The current quest is not complete. If you begin a new quest, your agent nodes will be reset. Your master node and Puppet code will not be affected.\n"))
       end

--- a/locales/quest.pot
+++ b/locales/quest.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Quest \n"
 "Report-Msgid-Bugs-To: learningvm@puppet.com\n"
-"POT-Creation-Date: 2018-01-17 10:08-0800\n"
-"PO-Revision-Date: 2018-01-17 10:08-0800\n"
+"POT-Creation-Date: 2018-02-27 20:16-0800\n"
+"PO-Revision-Date: 2018-02-27 20:16-0800\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -50,12 +50,16 @@ msgstr ""
 msgid "Begin a quest"
 msgstr ""
 
+#: ../bin/quest:101 ../bin/quest:103
+msgid "Refer to the Quest Guide or use the \"quest list\" command."
+msgstr ""
+
 #: ../bin/quest:101
-msgid "You must specify a quest name. Refer to the Quest Guide or use the \"quest list\" command."
+msgid "You must specify a quest name. %{refer_to}"
 msgstr ""
 
 #: ../bin/quest:103
-msgid "%{quest} is not a valid quest name. Refer to the Quest Guide or use the \"quest list\" command."
+msgid "%{quest} is not a valid quest name. %{refer_to}"
 msgstr ""
 
 #: ../bin/quest:105


### PR DESCRIPTION
After consulting with @LarissaLane, the following solution is better for localization:

Separate the string resource back to two string resources is cost-efficient since having one shared string resource keeps the word count (to be translated) low.

To avoid concatenation, use a placeholder at the tail of the first string. That way, the translator can decide whether to keep the space or not.