### PR TITLE
Fix dependency on gem that doesn't follow semver guidelines

### DIFF
--- a/quest.gemspec
+++ b/quest.gemspec
@@ -3,9 +3,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name = 'quest'
-  spec.version = '1.2.2'
-  spec.authors = ['Kevin Henner']
-  spec.email = ['kevin@puppetlabs.com']
+  spec.version = '1.2.3'
+  spec.authors = ['Services Portfolio']
+  spec.email = ['services-portfolio@puppet.com']
   spec.summary = 'Track completion of configuration management tasks.'
   spec.description = "quest uses serverspec to track completion of configuration management related learning tasks."
   spec.homepage = 'http://github.com/puppetlabs/quest'
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra', '~> 1.4'
   spec.add_dependency 'highline', '~> 1.7'
   spec.add_dependency 'net-ssh', '~> 4.1'
-  spec.add_dependency 'timers', '~> 4.1'
+  spec.add_dependency 'timers', '~> 4.1.0'
   spec.add_dependency 'hitimes', '~> 1.2'
   spec.add_dependency 'gettext-setup', '~> 0.24'
 end


### PR DESCRIPTION
Version >= 4.2.0 specifies a required Ruby version whereas 4.1.z does not. That caused an LVM build failure, and since it's currently unknown how to publish an upgraded quest gem to rubygems.org, the correct `timers` gem had to be preinstalled before installing the quest gem. See: https://github.com/puppetlabs/pltraining-bootstrap/blob/396af7ee4281a420d19ab98b1e50b040718c3638/manifests/profile/rubygems.pp#L32-L36

This PR gets the proper change into the quest gemspec, and if this gem is updated on rubygems.org at some point, it will have the correct dependencies.